### PR TITLE
ODP-6342 : Bump Netty version to 4.1.132.Final

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -147,7 +147,7 @@ metrics-graphite/3.1.5//metrics-graphite-3.1.5.jar
 metrics-json/3.1.5//metrics-json-3.1.5.jar
 metrics-jvm/3.1.5//metrics-jvm-3.1.5.jar
 minlog/1.3.0//minlog-1.3.0.jar
-netty-all/4.1.127.Final//netty-all-4.1.127.Final.jar
+netty-all/4.1.132.Final//netty-all-4.1.132.Final.jar
 netty/3.9.9.Final//netty-3.9.9.Final.jar
 objenesis/2.5.1//objenesis-2.5.1.jar
 okhttp/4.9.2//okhttp-4.9.2.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -148,7 +148,7 @@ metrics-graphite/3.1.5//metrics-graphite-3.1.5.jar
 metrics-json/3.1.5//metrics-json-3.1.5.jar
 metrics-jvm/3.1.5//metrics-jvm-3.1.5.jar
 minlog/1.3.0//minlog-1.3.0.jar
-netty-all/4.1.127.Final//netty-all-4.1.127.Final.jar
+netty-all/4.1.132.Final//netty-all-4.1.132.Final.jar
 netty/3.9.9.Final//netty-3.9.9.Final.jar
 objenesis/2.5.1//objenesis-2.5.1.jar
 okhttp/4.9.2//okhttp-4.9.2.jar

--- a/dev/deps/spark-deps-hadoop-3.1
+++ b/dev/deps/spark-deps-hadoop-3.1
@@ -165,7 +165,7 @@ metrics-json/3.1.5//metrics-json-3.1.5.jar
 metrics-jvm/3.1.5//metrics-jvm-3.1.5.jar
 minlog/1.3.0//minlog-1.3.0.jar
 mssql-jdbc/6.2.1.jre7//mssql-jdbc-6.2.1.jre7.jar
-netty-all/4.1.127.Final//netty-all-4.1.127.Final.jar
+netty-all/4.1.132.Final//netty-all-4.1.132.Final.jar
 netty/3.9.9.Final//netty-3.9.9.Final.jar
 nimbus-jose-jwt/4.41.1//nimbus-jose-jwt-4.41.1.jar
 objenesis/2.5.1//objenesis-2.5.1.jar

--- a/dev/deps/spark-deps-hadoop-3.2
+++ b/dev/deps/spark-deps-hadoop-3.2
@@ -189,7 +189,7 @@ metrics-jmx/4.1.1//metrics-jmx-4.1.1.jar
 metrics-json/4.1.1//metrics-json-4.1.1.jar
 metrics-jvm/4.1.1//metrics-jvm-4.1.1.jar
 minlog/1.3.0//minlog-1.3.0.jar
-netty-all/4.1.127.Final//netty-all-4.1.127.Final.jar
+netty-all/4.1.132.Final//netty-all-4.1.132.Final.jar
 nimbus-jose-jwt/4.41.1//nimbus-jose-jwt-4.41.1.jar
 objenesis/2.6//objenesis-2.6.jar
 okhttp/2.7.5//okhttp-2.7.5.jar

--- a/pom.xml
+++ b/pom.xml
@@ -688,7 +688,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.127.Final</version>
+        <version>4.1.132.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
This patch was tested locally.