### PR TITLE
OSV-19655 - CVE - Increasing avro version to fix CVE-2023-39410

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,8 +157,8 @@
     <ivy.version>2.5.1</ivy.version>
     <oro.version>2.0.8</oro.version>
     <codahale.metrics.version>3.1.5</codahale.metrics.version>
-    <avro.version>1.8.2</avro.version>
-    <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
+    <avro.version>1.11.5</avro.version>
+    <avro.mapred.classifier></avro.mapred.classifier>
     <aws.kinesis.client.version>1.12.0</aws.kinesis.client.version>
     <!-- Should be consistent with Kinesis client dependency -->
     <aws.java.sdk.version>1.11.655</aws.java.sdk.version>


### PR DESCRIPTION
Bumps Apache Avro 1.8.2 -> 1.11.5 to fix:
- CVE-2023-39410 (OSV-19655)
- CVE-2024-47561 (OSV-19654)

Also removes the obsolete avro-mapred `hadoop2` classifier (dropped in Avro 1.9+). Full make-distribution build passes.