### PR TITLE
OSV-19665 - CVE - Increasing okio version to fix CVE-2023-3635

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1879,6 +1879,11 @@
         <version>0.27</version>
       </dependency>
       <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio</artifactId>
+        <version>1.17.6</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.orc</groupId>
         <artifactId>orc-mapreduce</artifactId>
         <version>${orc.version}</version>


### PR DESCRIPTION
Overrides com.squareup.okio:okio 1.15.0 -> 1.17.6 (last 1.x, fixes CVE-2023-3635). okio is pulled transitively via io.fabric8:kubernetes-client -> okhttp3 3.12.0. Full make-distribution build passes.