### PR TITLE
OSV-19666 - CVE - Increasing commons-lang3 version to fix CVE-2025-48924

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
     <!-- org.apache.commons/commons-lang/-->
     <commons-lang2.version>2.6</commons-lang2.version>
     <!-- org.apache.commons/commons-lang3/-->
-    <commons-lang3.version>3.17.0</commons-lang3.version>
+    <commons-lang3.version>3.18.0</commons-lang3.version>
     <datanucleus-core.version>3.2.10</datanucleus-core.version>
     <guava.version>33.4.0-jre</guava.version>
     <guava.failureaccess.version>1.0.2</guava.failureaccess.version>


### PR DESCRIPTION
Bumps commons-lang3 3.17.0 -> 3.18.0 to fix CVE-2025-48924. Full make-distribution build passes.