### PR TITLE
OSV-19642 - CVE - Increasing httpclient version to fix CVE-2020-13956

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
     <!-- the producer is used in tests -->
     <aws.kinesis.producer.version>0.12.8</aws.kinesis.producer.version>
     <!--  org.apache.httpcomponents/httpclient-->
-    <commons.httpclient.version>4.5.6</commons.httpclient.version>
+    <commons.httpclient.version>4.5.13</commons.httpclient.version>
     <commons.httpcore.version>4.4.10</commons.httpcore.version>
     <!--  commons-httpclient/commons-httpclient-->
     <httpclient.classic.version>3.1</httpclient.classic.version>


### PR DESCRIPTION
Bumps httpclient 4.5.6 -> 4.5.13 (commons.httpclient.version) to fix CVE-2020-13956. Full make-distribution build passes.