### PR TITLE
OSV-19635 - CVE - Increasing commons-configuration2 version to fix CVE-2026-45205

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2117,6 +2117,11 @@
         <version>1.33</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-configuration2</artifactId>
+        <version>2.15.0</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.arrow</groupId>
         <artifactId>arrow-vector</artifactId>
         <version>${arrow.version}</version>


### PR DESCRIPTION
Pins transitive commons-configuration2 (from Hadoop) 2.10.1 -> 2.15.0 via dependencyManagement to fix CVE-2026-45205. Verified resolved to 2.15.0; full make-distribution build passes.