### PR TITLE
OSV-14964 - CVE - Increasing dnsjava version to fix CVE-2024-25638

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2117,6 +2117,11 @@
         <version>1.33</version>
       </dependency>
       <dependency>
+        <groupId>dnsjava</groupId>
+        <artifactId>dnsjava</artifactId>
+        <version>3.6.0</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.arrow</groupId>
         <artifactId>arrow-vector</artifactId>
         <version>${arrow.version}</version>


### PR DESCRIPTION
Pins transitive dnsjava (from Hadoop) 2.1.7 -> 3.6.0 via dependencyManagement to fix CVE-2024-25638. Aligned with ODP Hadoop dnsjava 3.6.0. Verified resolved to 3.6.0; full make-distribution build passes.