### PR TITLE
OCR-2525 Bundle Kafka 0.10 DStream connector into the Spark 2 distribution

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -79,6 +79,27 @@
         <artifactId>spark-avro_${scala.binary.version}</artifactId>
         <version>${project.version}</version>
     </dependency>
+    <!--
+      OCR-2525: bundle the Kafka 0.10 DStream connector into the distribution jars/ folder so
+      spark-submit jobs find org.apache.spark.streaming.kafka010.* out-of-the-box, as CDP shipped it.
+      The connector is an external module (not on the assembly path upstream) and was therefore
+      absent from the ODP runtime.
+    -->
+    <dependency>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-streaming-kafka-0-10_${scala.binary.version}</artifactId>
+        <version>${project.version}</version>
+    </dependency>
+    <!--
+      OCR-2525: bundle kafka-clients explicitly so the connector's runtime dependency is in jars/
+      and the distribution is self-contained (as CDP's was). Version matches kafka.version (2.0.0)
+      pinned in external/kafka-0-10/pom.xml; keep the two in sync.
+    -->
+    <dependency>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka-clients</artifactId>
+        <version>2.0.0</version>
+    </dependency>
 
     <!--
       Because we don't shade dependencies anymore, we need to restore Guava to compile scope so


### PR DESCRIPTION
The spark-streaming-kafka-0-10 connector source is present in the ODP Spark 2 reactor and builds fine, but the jar was never bundled into the distribution jars/ folder because the connector is an external module and is not a dependency of the assembly (upstream default - it is meant to be pulled via --packages). CDP shipped it in-runtime; ODP did not, so jobs failed to find org.apache.spark.streaming.kafka010.{KafkaUtils,OffsetRange,HasOffsetRanges, ConsumerStrategies,LocationStrategies,KafkaRDD}.

Add spark-streaming-kafka-0-10 (alongside spark-avro, which is bundled the same way) plus its kafka-clients runtime dependency to assembly/pom.xml so both land in the distribution jars/ and are on the default classpath out-of-the-box.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

Locally and in customer environment.
