### PR TITLE
ODP-7460: Fix Spark 2 hive-thriftserver build against Hadoop 3.x

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/HiveCommandOperation.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/HiveCommandOperation.java
@@ -90,8 +90,8 @@ public class HiveCommandOperation extends ExecuteStatementOperation {
 
 
   private void tearDownSessionIO() {
-    IOUtils.cleanup(LOG, parentSession.getSessionState().out);
-    IOUtils.cleanup(LOG, parentSession.getSessionState().err);
+    IOUtils.closeStreams(parentSession.getSessionState().out);
+    IOUtils.closeStreams(parentSession.getSessionState().err);
   }
 
   @Override
@@ -206,7 +206,7 @@ public class HiveCommandOperation extends ExecuteStatementOperation {
 
   private void resetResultReader() {
     if (resultReader != null) {
-      IOUtils.cleanup(LOG, resultReader);
+      IOUtils.closeStreams(resultReader);
       resultReader = null;
     }
   }


### PR DESCRIPTION
Replace IOUtils.cleanup(Log, Closeable) with IOUtils.closeStreams(Closeable) in HiveCommandOperation.java. The cleanup() overload taking a Log was removed in Hadoop 3.x; closeStreams() is the direct replacement.
